### PR TITLE
Allow labeling procedures and memory addresses from the GUI

### DIFF
--- a/awake/database.py
+++ b/awake/database.py
@@ -197,10 +197,14 @@ class Database(object):
         """
         c = self.connection.cursor()
         c.execute('select name from tags where addr=?', (addr,))
-        if c.fetchone():
+        existing_name = c.fetchone()
+        if existing_name and name:
             print('updating')
             c.execute('update tags set name=? where addr=?', (name, addr))
-        else:
+        elif existing_name and not name:
+            print('deleting')
+            c.execute('delete from tags where addr=?', (addr,))
+        elif name:
             print('new')
             c.execute('insert into tags (addr, name) values (?, ?)', (addr, name))
         c.close()


### PR DESCRIPTION
The HTML UI had already a field to label and rename the current procedure or memory address. But the native GUI lacked this field.

![rename](https://user-images.githubusercontent.com/179923/29739482-82bbd788-8a5c-11e7-9551-934e6c2f36dc.gif)
