### PR TITLE
procedure: don’t fail when manual jump table config not found

### DIFF
--- a/awake/procedure.py
+++ b/awake/procedure.py
@@ -26,8 +26,8 @@ def manualJumptableLimit(proj, addr):
     try:
         return jumptables[str(addr)]
     except KeyError:
-        raise ValueError("Unknown jumptable at "+addr+"!")
-    
+        return None
+
 
 class ProcedureRangeAnalysis(object):
 


### PR DESCRIPTION
The current code throws an uncaught exception when the limits of a jump table are not manually defined.

Instead let the code attempt to use heuristics to find the jump table limits.