### PR TITLE
Import debug symbols

### DIFF
--- a/awake/database.py
+++ b/awake/database.py
@@ -163,7 +163,7 @@ class Database(object):
 
     def hasNameForAddress(self, addr):
         """
-        Have we already named this address (procudure/memory) in a tag?
+        Have we already named this address (procedure/memory) in a tag?
         First check if its in the default tags otherwise query the database
         :param addr: The address to find the name of
         :return: True if we have a name for this address, False otherwise

--- a/awake/debugsymbols.py
+++ b/awake/debugsymbols.py
@@ -65,8 +65,3 @@ class DebugSymbols(object):
                     symbols[str(normalized_address)] = label
         return symbols
 
-    def insertTags(self, project):
-        for address in self.symbols:
-            project.database.setNameForAddress(address, self.symbols[address])
-
-

--- a/awake/debugsymbols.py
+++ b/awake/debugsymbols.py
@@ -1,0 +1,57 @@
+# This file is part of Awake - GB decompiler.
+# Copyright (C) 2017 Pierre de La Morinerie (kemenaran)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+class DebugSymbols(object):
+    """
+    Simple class which loads a rgbds debug symbols file on initialize and allows other classes
+    to lookup the symbols by address
+    """
+
+    def __init__(self, filename):
+        """
+        This initialises the debug symbols file specified in the filename parameter.
+
+        :type filename: string
+        :param filename: The rom filename to load as data
+        :return a DebugSymbol object on success, or None on failure (for instance if the file doesn't exist)
+        """
+        if not os.path.isfile(filename):
+            return None
+        self.symbols = self._readSymfile(filename)
+
+    @staticmethod
+    def _readSymfile(path):
+      """
+      Return a dict of labels extracted from an rgbds .sym file, sorted by bank.
+      """
+      symbols = {}
+      for line in open(path):
+          line = line.strip().split(';')[0]
+          if line:
+              bank_address, label = line.split(' ')[:2]
+              bank_str, address_str = bank_address.split(':')
+              # Ensure bank and memory address have leading zeros
+              address = bank_str.rjust(4, '0') + ':' + address_str.rjust(4, '0')
+              symbols[address] = label
+      return symbols
+
+    def insertTags(self, project):
+      for address in self.symbols:
+          project.database.setNameForAddress(address, self.symbols[address])
+
+

--- a/awake/debugsymbols.py
+++ b/awake/debugsymbols.py
@@ -22,6 +22,20 @@ class DebugSymbols(object):
     to lookup the symbols by address
     """
 
+    """
+    This creates a debug symbols object, backed by the file specified in the filename parameter.
+
+    :type filename: string
+    :param filename: The rom filename to load as data
+    :return a new DebugSymbol object on success, or None on failure (for instance if the file doesn't exist)
+    """
+    def __new__(cls, filename, exclude_pattern=None):
+        if os.path.isfile(filename):
+            return super(DebugSymbols, cls).__new__(cls, filename, exclude_pattern=None)
+        else:
+            print "DebugSymbols: file '" + filename + "' not found."
+            return None
+
     def __init__(self, filename, exclude_pattern=None):
         """
         This initialises the debug symbols file specified in the filename parameter.
@@ -30,8 +44,6 @@ class DebugSymbols(object):
         :param filename: The rom filename to load as data
         :return a DebugSymbol object on success, or None on failure (for instance if the file doesn't exist)
         """
-        if not os.path.isfile(filename):
-            return None
         self.symbols = self._readSymfile(filename, exclude_pattern)
 
     @staticmethod

--- a/awake/debugsymbols.py
+++ b/awake/debugsymbols.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, re
+from awake import address
 
 class DebugSymbols(object):
     """
@@ -57,14 +58,11 @@ class DebugSymbols(object):
         for line in open(path):
             line = line.strip().split(';')[0]
             if line:
-                bank_address, label = line.split(' ')[:2]
-                bank_str, address_str = bank_address.split(':')
-                # Ensure bank and memory address have leading zeros
-                address = bank_str.rjust(4, '0') + ':' + address_str.rjust(4, '0')
-
-                is_excluded = exclude and exclude.match(label)
-                if not is_excluded:
-                    symbols[address] = label
+                sym_address, label = line.split(' ')[:2]
+                is_label_excluded = exclude and exclude.match(label)
+                if not is_label_excluded:
+                    normalized_address = address.fromConventional(sym_address)
+                    symbols[str(normalized_address)] = label
         return symbols
 
     def insertTags(self, project):

--- a/awake/gui.py
+++ b/awake/gui.py
@@ -72,6 +72,9 @@ class MainWindow(tk.Toplevel):
         open_button = ttk.Button(toolbar, text="Open...", command=self.selectRom)
         open_button.pack(side='left')
 
+        self.debug_symbols_button = ttk.Button(toolbar, text="Import debug symbols...", command=self.importDebugSymbols)
+        self.debug_symbols_button.pack(side='left')
+
         self.history = History(toolbar)
         self.history.pack(side='left')
 
@@ -112,6 +115,7 @@ class MainWindow(tk.Toplevel):
             self.history.navigate(url)
 
         if not self.proj:
+            self.debug_symbols_button.configure(state='disabled')
             self.export_button.configure(state='disabled')
             self.server_button.configure(state='disabled')
             self.history.disable()
@@ -132,6 +136,17 @@ class MainWindow(tk.Toplevel):
         fresh = MainWindow(getTkRoot(), filename)
         fresh.geometry(self.geometry())
         self.destroy()
+
+    def importDebugSymbols(self):
+        if not self.proj:
+            return
+
+        filename = askopenfilename(title="Select debug symbols", parent=self, filetypes=[('RGBDS debug symbols (*.sym)', '*.sym'), ('All files', '*.*')])
+        if not filename:
+            return
+
+        self.proj.importDebugSymbols(filename)
+        self.main.reloadPage()
 
     def wait(self):
         self.wait_window(self)

--- a/awake/project.py
+++ b/awake/project.py
@@ -21,6 +21,7 @@ from awake.disasm import Z80Disasm
 from awake.config import Config
 from awake.flow import ProcedureFlowCache
 from awake.rom import Rom
+from awake.debugsymbols import DebugSymbols
 
 class Project(object):
     """
@@ -42,6 +43,9 @@ class Project(object):
         if romconfig.get(['Database','Auto-Upgrade']):
             updb.doUpgrade(self.filename)
         self.database = Database(self.filenameBase()+'.awakedb')
+        self.debug_symbols = DebugSymbols(self.filenameBase()+'.sym')
+        if self.debug_symbols:
+          self.debug_symbols.insertTags(self)
         self.disasm = Z80Disasm(self)
         self.flow = ProcedureFlowCache(self)
 

--- a/awake/project.py
+++ b/awake/project.py
@@ -43,7 +43,7 @@ class Project(object):
         if romconfig.get(['Database','Auto-Upgrade']):
             updb.doUpgrade(self.filename)
         self.database = Database(self.filenameBase()+'.awakedb')
-        self.debug_symbols = DebugSymbols(self.filenameBase()+'.sym')
+        self.debug_symbols = DebugSymbols(self.filenameBase()+'.sym', exclude_pattern='^label_*')
         if self.debug_symbols:
           self.debug_symbols.insertTags(self)
         self.disasm = Z80Disasm(self)

--- a/awake/project.py
+++ b/awake/project.py
@@ -43,11 +43,9 @@ class Project(object):
         if romconfig.get(['Database','Auto-Upgrade']):
             updb.doUpgrade(self.filename)
         self.database = Database(self.filenameBase()+'.awakedb')
-        self.debug_symbols = DebugSymbols(self.filenameBase()+'.sym', exclude_pattern='^label_*')
-        if self.debug_symbols:
-          self.debug_symbols.insertTags(self)
         self.disasm = Z80Disasm(self)
         self.flow = ProcedureFlowCache(self)
+        self.debug_symbols = None
 
     def filenameBase(self):
         """
@@ -55,6 +53,12 @@ class Project(object):
         :return: string holding the location of the rom file
         """
         return os.path.splitext(self.filename)[0]
+
+    def importDebugSymbols(self, filename):
+        self.debug_symbols = DebugSymbols(filename, exclude_pattern='^label_*')
+        if self.debug_symbols:
+            for (address, label) in self.debug_symbols.symbols.items():
+                self.database.setNameForAddress(address, label)
 
     def close(self):
     	"""


### PR DESCRIPTION
This PR allows to import debug symbols generated by the `rgbds` toolchain (`*.sym` files).

![load-debug-symbols](https://user-images.githubusercontent.com/179923/29916843-a649f3a6-8e5d-11e7-8edf-00d03f6842e5.gif)
