### PR TITLE
Fix opening of GBC files

### DIFF
--- a/upgrade_database.py
+++ b/upgrade_database.py
@@ -8,7 +8,7 @@ parser.add_argument('file', nargs='?', default='roms/blue.gb')
 
 def getDB(filename):
     split=os.path.splitext(filename)
-    if split[1]=='.gb':
+    if split[1]=='.gb' or split[1]=='.gbc':
         return split[0]+'.awakedb'
     if split[1]=='':
         return split[0]+'.awakedb'


### PR DESCRIPTION
The file selector lets the user select `*.gbc` files (instead of `*.gb) – but the database creation would not handle them.